### PR TITLE
Ping docutils to 0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx_rtd_theme
+docutils==0.16


### PR DESCRIPTION
docutils has a bug with sphinx so we need to use v0.16.

See https://github.com/readthedocs/sphinx_rtd_theme/issues/1111